### PR TITLE
Allow queueing of multiple ISOs

### DIFF
--- a/ciso.py
+++ b/ciso.py
@@ -222,8 +222,9 @@ def compress_iso(infile):
 		fout_2.close()
 
 def main(argv):
-	infile = argv[1]
-	compress_iso(infile)
+    for i in range(1, len(argv)):
+        infile = argv[i]
+        compress_iso(infile)
 
 if __name__ == '__main__':
 	sys.exit(main(sys.argv))


### PR DESCRIPTION
Currently you can nicely drag and drop an ISO onto ciso.py to create one.

This change allows you to drag and drop a bunch of ISOs onto ciso.py and they will be queued automatically. It does not change the command line usage, except you could do something like `python3 ciso.py first.iso second.iso third.iso` etc

Tested in windows